### PR TITLE
Update iaq_board.yaml

### DIFF
--- a/firmware/iaq_board.yaml
+++ b/firmware/iaq_board.yaml
@@ -348,7 +348,7 @@ sensor:
         name: "PM 10 Concentration"
         id: pm10
 
-    - platform: bme280
+    - platform: bme280_i2c
       temperature:
         name: "Temperature"
         oversampling: 1x


### PR DESCRIPTION
breaking change in esphome support of bme280 fixed
should fix https://github.com/nkitanov/iaq_board/issues/34